### PR TITLE
📦 Fix Missing package.json Generation in New Projects #32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,14 @@
         "@typescript-eslint/parser": "^8.45.0",
         "commander": "^14.0.1",
         "eslint": "^9.36.0",
+        "inquirer": "^12.9.6",
         "prettier": "^3.6.2",
         "tsup": "^8.3.5",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.45.0"
+      },
+      "bin": {
+        "auto-express": "dist/index.js"
       },
       "devDependencies": {
         "@types/commander": "^2.12.0",
@@ -1238,6 +1242,395 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.0.tgz",
+      "integrity": "sha512-JWaTfCxI1eTmJ1BIv86vUfjVatOdxwD0DAVKYevY8SazeUUZtW+tNbsdejVO1GYE0GXJW1N1ahmiC3TFd+7wZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.4.tgz",
+      "integrity": "sha512-2n9Vgf4HSciFq8ttKXk+qy+GsyTXPV1An6QAwe/8bkbbqvG4VW1I/ZY1pNu2rf+h9bdzMLPbRSfcNxkHBy/Ydw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.0",
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.18.tgz",
+      "integrity": "sha512-MilmWOzHa3Ks11tzvuAmFoAd/wRuaP3SwlT1IZhyMke31FKLxPiuDWcGXhU+PKveNOpAc4axzAgrgxuIJJRmLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.2.2.tgz",
+      "integrity": "sha512-yXq/4QUnk4sHMtmbd7irwiepjB8jXU0kkFRL4nr/aDBA2mDz13cMakEWdDwX3eSCTkk03kwcndD1zfRAIlELxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.0",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.20.tgz",
+      "integrity": "sha512-7omh5y5bK672Q+Brk4HBbnHNowOZwrb/78IFXdrEB9PfdxL3GudQyDk8O9vQ188wj3xrEebS2M9n18BjJoI83g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/external-editor": "^1.0.2",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.20",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.20.tgz",
+      "integrity": "sha512-Dt9S+6qUg94fEvgn54F2Syf0Z3U8xmnBI9ATq2f5h9xt09fs2IJXSCIXyyVHwvggKWFXEY/7jATRo2K6Dkn6Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/type": "^3.0.8",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
+      "integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.0",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.4.tgz",
+      "integrity": "sha512-cwSGpLBMwpwcZZsc6s1gThm0J+it/KIJ+1qFL2euLmSKUMGumJ5TcbMgxEjMjNHRGadouIYbiIgruKoDZk7klw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.20.tgz",
+      "integrity": "sha512-bbooay64VD1Z6uMfNehED2A2YOPHSJnQLs9/4WNiV/EK+vXczf/R988itL2XLDGTgmhMF2KkiWZo+iEZmc4jqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.20",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.20.tgz",
+      "integrity": "sha512-nxSaPV2cPvvoOmRygQR+h0B+Av73B01cqYLcr7NXcGXhbmsYfUb8fDdw2Us1bI2YsX+VvY7I7upgFYsyf8+Nug==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.0",
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.6.tgz",
+      "integrity": "sha512-68JhkiojicX9SBUD8FE/pSKbOKtwoyaVj1kwqLfvjlVXZvOy3iaSWX4dCLsZyYx/5Ur07Fq+yuDNOen+5ce6ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.2.4",
+        "@inquirer/confirm": "^5.1.18",
+        "@inquirer/editor": "^4.2.20",
+        "@inquirer/expand": "^4.0.20",
+        "@inquirer/input": "^4.2.4",
+        "@inquirer/number": "^3.0.20",
+        "@inquirer/password": "^4.0.20",
+        "@inquirer/rawlist": "^4.1.8",
+        "@inquirer/search": "^3.1.3",
+        "@inquirer/select": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.8.tgz",
+      "integrity": "sha512-CQ2VkIASbgI2PxdzlkeeieLRmniaUU1Aoi5ggEdm6BIyqopE9GuDXdDOj9XiwOqK5qm72oI2i6J+Gnjaa26ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/type": "^3.0.8",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.1.3.tgz",
+      "integrity": "sha512-D5T6ioybJJH0IiSUK/JXcoRrrm8sXwzrVMjibuPs+AgxmogKslaafy1oxFiorNI4s3ElSkeQZbhYQgLqiL8h6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.4.tgz",
+      "integrity": "sha512-Qp20nySRmfbuJBBsgPU7E/cL62Hf250vMZRzYDcBHty2zdD1kKCnoDFWRr0WO2ZzaXp3R7a4esaVGJUx0E6zvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.0",
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2281,7 +2674,7 @@
       "version": "24.6.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
       "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.13.0"
@@ -3198,6 +3591,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
+      "license": "MIT"
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -3236,6 +3635,15 @@
       "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -4147,6 +4555,22 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -4220,6 +4644,32 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/inquirer": {
+      "version": "12.9.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.6.tgz",
+      "integrity": "sha512-603xXOgyfxhuis4nfnWaZrMaotNT0Km9XwwBNWUKbIDqeCY89jGr2F9YPEMiNhU6XjIP4VoWISMBFfcc5NgrTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.0",
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/prompts": "^7.8.6",
+        "@inquirer/type": "^3.0.8",
+        "mute-stream": "^2.0.0",
+        "run-async": "^4.0.5",
+        "rxjs": "^7.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4240,7 +4690,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5275,6 +5724,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -5902,6 +6360,15 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/run-async": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5924,6 +6391,21 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -5962,7 +6444,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -6467,9 +6948,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tsup": {
       "version": "8.5.0",
@@ -6630,7 +7109,7 @@
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
       "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -6990,6 +7469,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,10 @@ import inquirer from 'inquirer';
 import { PackageManager, ProjectType } from './type';
 import { promises as fs } from 'fs';
 import * as path from 'path';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
 
 export async function promptProjectType(
   defaultType: ProjectType = 'api',
@@ -45,6 +49,35 @@ export function generateReadmeContent(projectName: string) {
   return `# ${projectName}\n\nWelcome to your new Express project!`;
 }
 
+export async function initializePackageManager(
+  projectPath: string,
+  packageManager: PackageManager,
+): Promise<void> {
+  console.log(`📦 Installing dependencies with ${packageManager}...`);
+  
+  try {
+    const installCommand = getInstallCommand(packageManager);
+    await execAsync(installCommand, { cwd: projectPath });
+    console.log(`✅ Dependencies installed successfully with ${packageManager}.`);
+  } catch (error) {
+    console.warn(`⚠️  Failed to install dependencies with ${packageManager}:`);
+    console.warn(`   ${error}`);
+    console.warn(`   You can manually install dependencies by running:`);
+    console.warn(`   cd ${path.basename(projectPath)} && ${getInstallCommand(packageManager)}`);
+  }
+}
+
+function getInstallCommand(packageManager: PackageManager): string {
+  switch (packageManager) {
+    case 'yarn':
+      return 'yarn install';
+    case 'pnpm':
+      return 'pnpm install';
+    default:
+      return 'npm install';
+  }
+}
+
 export async function generateExpressProjectMVC(
   projectPath: string,
   packageManager: PackageManager,
@@ -68,22 +101,35 @@ export async function generateExpressProjectMVC(
   const packageJson = {
     name: projectName,
     version: '1.0.0',
+    description: `Express MVC application - ${projectName}`,
     private: true,
     main: 'src/server.js',
     type: 'commonjs',
-    packageManager: packageManager,
     scripts: {
       dev: 'nodemon src/server.js',
       start: 'node src/server.js',
+      test: 'echo "Error: no test specified" && exit 1'
+    },
+    keywords: [
+      'express',
+      'mvc',
+      'nodejs',
+      'web-application'
+    ],
+    author: '',
+    license: 'ISC',
+    engines: {
+      node: '>=14.0.0',
+      npm: '>=6.0.0'
     },
     dependencies: {
       dotenv: '^16.4.5',
       express: '^4.19.2',
-      ejs: '^3.1.10',
+      ejs: '^3.1.10'
     },
     devDependencies: {
-      nodemon: '^3.1.7',
-    },
+      nodemon: '^3.1.7'
+    }
   };
 
   await fs.writeFile(
@@ -210,21 +256,34 @@ export async function generateExpressProjectAPI(
   const packageJson = {
     name: projectName,
     version: '1.0.0',
+    description: `Express API application - ${projectName}`,
     private: true,
     main: 'src/server.js',
     type: 'commonjs',
-    packageManager: packageManager,
     scripts: {
       dev: 'nodemon src/server.js',
       start: 'node src/server.js',
+      test: 'echo "Error: no test specified" && exit 1'
+    },
+    keywords: [
+      'express',
+      'api',
+      'rest',
+      'nodejs'
+    ],
+    author: '',
+    license: 'ISC',
+    engines: {
+      node: '>=14.0.0',
+      npm: '>=6.0.0'
     },
     dependencies: {
       dotenv: '^16.4.5',
-      express: '^4.19.2',
+      express: '^4.19.2'
     },
     devDependencies: {
-      nodemon: '^3.1.7',
-    },
+      nodemon: '^3.1.7'
+    }
   };
 
   await fs.writeFile(


### PR DESCRIPTION
## 📦 Fix Missing package.json Generation in New Projects

Fixes #32

### 🔍 Problem
The generated Express projects lacked a complete [package.json](cci:7://file:///c:/Users/HP/Desktop/auto-express1/auto-express/package.json:0:0-0:0) file with standard fields, making them non-functional by default and requiring manual setup.

### ✅ Solution
Enhanced the [package.json](cci:7://file:///c:/Users/HP/Desktop/auto-express1/auto-express/package.json:0:0-0:0) generation to include all standard fields and added automatic dependency installation support.

### 🚀 Changes Made

#### 1. Enhanced package.json Structure
- **Description**: Project-specific descriptions (`Express API application - {projectName}`)
- **Keywords**: Relevant tags for npm discoverability ([express](cci:7://file:///c:/Users/HP/Desktop/auto-express1/auto-express:0:0-0:0), `api`/`mvc`, `nodejs`)
- **Author**: Empty field ready for user customization
- **License**: ISC as default (Node.js standard)
- **Engines**: Node.js version requirements (`>=14.0.0`)
- **Test Script**: Placeholder test command

#### 2. Automatic Dependency Installation
- **New `--install` flag**: Automatically installs dependencies after project creation
- **Multi-package manager support**: Works with npm, yarn, and pnpm via `--pm` flag
- **Error handling**: Graceful fallback with manual installation instructions
- **Smart CLI output**: Different next steps based on installation status

#### 3. Improved User Experience
- **Enhanced help text**: Includes examples and clear option descriptions
- **Better feedback**: Progress indicators and success/warning messages
- **Package manager integration**: Respects `--pm` flag for installation commands

### 📁 Files Modified
- [src/utils.ts](cci:7://file:///c:/Users/HP/Desktop/auto-express1/auto-express/src/utils.ts:0:0-0:0): Enhanced package.json generation + added [initializePackageManager()](cci:1://file:///c:/Users/HP/Desktop/auto-express1/auto-express/src/utils.ts:51:0-67:1)
- [src/index.ts](cci:7://file:///c:/Users/HP/Desktop/auto-express1/auto-express/src/index.ts:0:0-0:0): Added `--install` option and integrated auto-installation

### 🧪 Testing
- ✅ API projects generate complete package.json with correct dependencies
- ✅ MVC projects include EJS dependency and appropriate keywords
- ✅ Package manager flags work correctly (npm, yarn, pnpm)
- ✅ Auto-installation feature works with error handling
- ✅ Backward compatibility maintained

### 📖 Usage Examples
```bash
# Basic project creation (enhanced package.json)
auto-express my-app

# MVC project with automatic dependency installation
auto-express my-app --type mvc --install

# Use specific package manager
auto-express my-app --pm yarn --install