### PR TITLE
feat(testing): Add Jest configuration and migrate CLI test to TypeScr…

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  // Tests can be slow because they scaffold a new project
+  testTimeout: 30000,
+  // Automatically clear mock calls, instances, contexts and results before every test
+  clearMocks: true,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,11 @@
       },
       "devDependencies": {
         "@types/commander": "^2.12.0",
+        "@types/jest": "^30.0.0",
         "@types/node": "^24.6.2",
         "globals": "^16.4.0",
         "jest": "^30.2.0",
+        "ts-jest": "^29.4.4",
         "tsup": "^8.3.5",
         "typescript": "^5.6.3"
       }
@@ -2677,6 +2679,17 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3493,6 +3506,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -4542,6 +4568,28 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "license": "MIT"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -5596,6 +5644,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5644,6 +5699,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -5707,6 +5769,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -5779,6 +5851,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-int64": {
@@ -6958,6 +7037,72 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.4.tgz",
+      "integrity": "sha512-ccVcRABct5ZELCT5U0+DZwkXMCcOCLi2doHRrKy1nK/s7J7bch6TzJMsrY09WxgUUIP/ITfmcDS8D2yl63rnXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.2",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -7119,6 +7264,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
@@ -7268,6 +7427,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
   "bin": {
     "auto-express": "./dist/index.js"
   },
-"scripts": {
-  "build": "tsup",
-  "pretest": "npm run build",
-  "lint": "eslint . --ext .ts",
-  "format": "prettier --write .",
-  "test": "jest"
-},
+  "scripts": {
+    "build": "tsup",
+    "pretest": "npm run build",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier --write .",
+    "test": "jest"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/arya2004/autoexpress.git"
@@ -30,9 +30,11 @@
   "description": "CLI to generate Express.js projects",
   "devDependencies": {
     "@types/commander": "^2.12.0",
+    "@types/jest": "^30.0.0",
     "@types/node": "^24.6.2",
     "globals": "^16.4.0",
     "jest": "^30.2.0",
+    "ts-jest": "^29.4.4",
     "tsup": "^8.3.5",
     "typescript": "^5.6.3"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ import {
   promptProjectType,
   initializePackageManager,
 } from './utils';
-import { getVersion } from './helpers/version';
+
+// import { getVersion } from './helpers/version';
 
 export function sayHello() {
   console.log('HEllo');
@@ -88,13 +89,15 @@ async function createProject(projectName: string, options: ProjectOptions) {
     try {
       await initializePackageManager(projectPath, pm);
     } catch (error) {
-      console.warn('⚠️  Dependency installation failed, but project was created successfully.');
+      console.warn(
+        '⚠️  Dependency installation failed, but project was created successfully.',
+      );
     }
   }
 
   console.log('\n✨ Project setup complete!');
   console.log(`Move into your new project: cd ${projectName}`);
-  
+
   if (!options.install) {
     console.log('\nNext steps:');
     if (pm === 'yarn') {
@@ -121,7 +124,7 @@ async function createProject(projectName: string, options: ProjectOptions) {
 
 async function main() {
   const version = await getVersion();
-  
+
   const program = new Command();
 
   program
@@ -134,7 +137,11 @@ async function main() {
       'npm',
     )
     .option('--type <type>', 'specify project type (api, mvc)')
-    .option('--install', 'automatically install dependencies after project creation', false);
+    .option(
+      '--install',
+      'automatically install dependencies after project creation',
+      false,
+    );
 
   program
     .argument('<project-name>', 'The name of the project to create')
@@ -152,7 +159,11 @@ async function main() {
       'npm',
     )
     .option('--type <type>', 'specify project type (api, mvc)')
-    .option('--install', 'automatically install dependencies after project creation', false)
+    .option(
+      '--install',
+      'automatically install dependencies after project creation',
+      false,
+    )
     .action(async (projectName: string, cmdOptions: ProjectOptions) => {
       const globalOptions = program.opts<ProjectOptions>();
       const options = { ...globalOptions, ...cmdOptions };
@@ -161,7 +172,9 @@ async function main() {
 
   program
     .command('init')
-    .description('Start an interactive CLI to create a new project (coming soon)')
+    .description(
+      'Start an interactive CLI to create a new project (coming soon)',
+    )
     .action(() => {
       console.log('Interactive init is not implemented yet. Use:');
       console.log('  auto-express <project-name>');
@@ -197,3 +210,4 @@ main().catch((error) => {
   console.error('Error initializing CLI:', error);
   process.exit(1);
 });
+


### PR DESCRIPTION
…ipt : Closes #35

---
name: Pull Request 207
about: Submit a Pull Request to contribute to the project
title: "feat(testing): Configure Jest and Migrate CLI Test to TypeScript"
labels: ""
assignees: ""
---

**What does this PR do?**
This pull request introduces Jest for testing and migrates the existing command-line interface test from JavaScript to TypeScript. The main goals of this change are to align the testing environment with the project's TypeScript-first approach and improve the overall robustness of the test suite.

The key changes include:
- A new jest.config.js file is added to configure the test environment with ts-jest.
- The cli.test.js file has been converted to cli.test.ts, adding full type safety.
- Required development dependencies (jest, ts-jest, @types/jest) have been installed.
- Fixed a build error in `index.ts` by removing a conflicting import (of getVersion function) to allow the tests to run. 

**Related issues**
This PR resolves issue #35.

**Checklist**
Please ensure the following before submitting:

- [✓] Code is linted and follows the project's style guidelines
- [✓] All tests pass successfully
- [   ] Relevant documentation is updated (if applicable)
- [✓] You have tested the changes locally

**Additional context**
This contribution is part of Hacktoberfest. Migrating to ts-jest enables writing future tests directly in TypeScript, which will help catch type-related bugs and make the test suite easier to maintain.
